### PR TITLE
feat: convert back to StringLiteral

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prettier-plugin-class-breaker",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A Prettier plugin for JSX that formats long CSS class strings into multiple lines. It optimizes class name readability in JSX, supporting TypeScript and standard syntax.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/utils/breakClassName.ts
+++ b/src/utils/breakClassName.ts
@@ -27,7 +27,7 @@ export function breakClassName(
     }
   }
 
-  brokenClasses += '\n' + baseIndentation + extraSpace
+  brokenClasses += '\n' + baseIndentation + indentCharacter.repeat(indentSize / 2)
 
   const templateElement = t.templateElement({ raw: brokenClasses, cooked: brokenClasses }, true)
   const templateLiteral = t.templateLiteral([templateElement], [])

--- a/src/utils/classBreakerPreprocess.ts
+++ b/src/utils/classBreakerPreprocess.ts
@@ -31,6 +31,7 @@ export const classBreakerPreprocess = async (parser: Parser): Promise<Parser> =>
         JSXAttribute(path) {
           if (path.node.name.name === 'className') {
             let classValue
+            let isTemplateLiteral = false
 
             if (path.node.value?.type === 'StringLiteral') {
               classValue = path.node.value.value
@@ -38,6 +39,7 @@ export const classBreakerPreprocess = async (parser: Parser): Promise<Parser> =>
               path.node.value?.type === 'JSXExpressionContainer' &&
               path.node.value.expression.type === 'TemplateLiteral'
             ) {
+              isTemplateLiteral = true
               classValue = path.node.value.expression.quasis
                 .map((quasi) => quasi.value.raw)
                 .join('')
@@ -57,6 +59,10 @@ export const classBreakerPreprocess = async (parser: Parser): Promise<Parser> =>
                   path.node.value = t.jsxExpressionContainer(result.expression)
                   modified = true
                 }
+              } else if (isTemplateLiteral && classes.length <= lineBreakAfterClasses) {
+                // Convert back to StringLiteral
+                path.node.value = t.stringLiteral(classValue)
+                modified = true
               }
             }
           }


### PR DESCRIPTION
- Enhanced logic to automatically revert classNames to a single-line string literal when the total number of classes falls below the threshold set in `lineBreakAfterClasses`, accommodating dynamic class content changes.